### PR TITLE
Support webpath in openshift for sites with a sub-path.

### DIFF
--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -24,7 +24,7 @@ if [ "${WEB_PATH}" == "/" ]; then
   echo "---> Unsetting \$WEB_PATH to avoid an apache alias being created."
   unset WEB_PATH
 else
-  sed -i "s@# RewriteBase /@RewriteBase ${WEB_PATH}@g" /code/web/.htaccess
+  sed -i "s@# RewriteBase /\$@RewriteBase ${WEB_PATH}@g" /code/web/.htaccess
 fi
 
 echo "---> Symlinking public and private directories to /shared."

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -23,6 +23,8 @@ echo "---> \$WEB_PATH is set to: ${WEB_PATH}"
 if [ "${WEB_PATH}" == "/" ]; then
   echo "---> Unsetting \$WEB_PATH to avoid an apache alias being created."
   unset WEB_PATH
+else
+  sed -i "s@# RewriteBase /@RewriteBase ${WEB_PATH}@g" /code/web/.htaccess
 fi
 
 echo "---> Symlinking public and private directories to /shared."


### PR DESCRIPTION
This used to be done by setSitePath() in RoboFileBase at deploy time, needs to be done at runtime in the s2i for openshift.

Tricky to rest, but you can run the sed without the '-i' in a running openshift container to see the output and that it updates the RewriteBase correctly.