### PR TITLE
Drupal console, Drush and Robo are all in projects now that Drush 9 d…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,7 @@ RUN apt-get update \
 && apt-get -y autoremove && apt-get -y autoclean && apt-get clean && rm -rf /var/lib/apt/lists /tmp/* /var/tmp/*
 
 # Install Drupal tools: Robo, Drush, Drupal console and Composer.
-RUN wget -O /usr/local/bin/robo https://github.com/consolidation/Robo/releases/download/1.0.4/robo.phar && chmod +x /usr/local/bin/robo \
-&& wget -O /usr/local/bin/drush https://s3.amazonaws.com/files.drush.org/drush.phar && chmod +x /usr/local/bin/drush \
-&& wget -O /usr/local/bin/drupal https://drupalconsole.com/installer && chmod +x /usr/local/bin/drupal \
-&& wget -q https://getcomposer.org/installer -O - | php -- --install-dir=/usr/local/bin --filename=composer
+RUN wget -q https://getcomposer.org/installer -O - | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Make bash the default shell.
 RUN ln -sf /bin/bash /bin/sh


### PR DESCRIPTION
…epends on Robo.

Removes all the Drupal tools, because they're expected to be in the app via composer dependencies.

There's a Drush 9 branch open for ua-wcms-d8... and Shepherd distro.