### PR TITLE
Added configuration for apache2 mpm_prefork module.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN ln -sf /bin/bash /bin/sh
 
 # Apache config.
 COPY ./files/apache2.conf /etc/apache2/apache2.conf
+COPY ./files/mpm_prefork.conf /etc/apache2/mods-available/mpm_prefork.conf
 
 # PHP config.
 COPY ./files/php_custom.ini /etc/php/7.2/mods-available/php_custom.ini

--- a/files/mpm_prefork.conf
+++ b/files/mpm_prefork.conf
@@ -1,0 +1,15 @@
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# MaxRequestWorkers: maximum number of server processes allowed to start
+# MaxConnectionsPerChild: maximum number of requests a server process serves
+
+# These values based on template from https://github.com/previousnext/tuner/
+<IfModule mpm_prefork_module>
+	StartServers           2
+	MinSpareServers        2
+	MaxSpareServers        2
+	MaxRequestWorkers      4
+	MaxConnectionsPerChild 1024
+</IfModule>


### PR DESCRIPTION
Overrides the default values provided by the base image.

```
<IfModule mpm_prefork_module>
	StartServers			 5 -> 2
	MinSpareServers		  5 -> 2
	MaxSpareServers		 10 ->2
	MaxRequestWorkers	  150 -> 4
	MaxConnectionsPerChild   0 -> 1024
</IfModule>
```

The main change here is `MaxRequestWorkers`. The value of `4` has been derived from this formula:

```
$TotalMemory = 1GB
$AverageProcSize = 128MB
$MaxClients = $TotalMemory / $AverageProcSize
```

Logic derived from https://github.com/previousnext/tuner