### PR TITLE
SAPP-5107 new newrelic package signing key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM ubuntu:24.04
 LABEL MAINTAINER="Michael Priest <michael.priest@adelaide.edu.au>"
 
 LABEL io.k8s.description="Platform for serving Drupal PHP apps in Shepherd" \
-      io.k8s.display-name="Shepherd Drupal" \
-      io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,shepherd,drupal,php,apache" \
-      io.openshift.s2i.scripts-url="image:///usr/local/s2i"
+  io.k8s.display-name="Shepherd Drupal" \
+  io.openshift.expose-services="8080:http" \
+  io.openshift.tags="builder,shepherd,drupal,php,apache" \
+  io.openshift.s2i.scripts-url="image:///usr/local/s2i"
 
 ARG PHP="8.3"
 
@@ -19,22 +19,18 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=Australia/Adelaide
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# Workaround for New Relic package being signed with an unsupported signing key.
-# See https://support.newrelic.com/s/hubtopic/aAXPh000000BZYjOAO/gpg-errors-when-installing-linux-net-and-php-agents-on-ubuntu-noble-2404
-RUN apt-config dump | grep -we 'APT::Key::Assert-Pubkey-Algo "' | sed 's/";/,dsa1024";/' | tee /etc/apt/apt.conf.d/99PubKeyAlgoWorkaround
-
 # Upgrade all currently installed packages and install web server packages.
 RUN apt-get update \
-&& apt-get -y --no-install-recommends install ca-certificates apt apt-utils \
-&& apt-get -y upgrade \
-&& apt-get -y --no-install-recommends install openssh-client patch software-properties-common locales gnupg2 gpg-agent wget \
-&& sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen \
-&& locale-gen en_AU.UTF-8 \
-&& wget -q -O- https://download.newrelic.com/548C16BF.gpg | apt-key add - \
-&& echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& apt-get -y update \
-&& apt-get -y upgrade \
-&& apt-get -y --no-install-recommends install \
+  && apt-get -y --no-install-recommends install ca-certificates apt apt-utils \
+  && apt-get -y upgrade \
+  && apt-get -y --no-install-recommends install openssh-client patch software-properties-common locales gnupg2 gpg-agent wget \
+  && sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen \
+  && locale-gen en_AU.UTF-8 \
+  && wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/download.newrelic.com-newrelic.gpg \
+  && echo 'deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+  && apt-get -y update \
+  && apt-get -y upgrade \
+  && apt-get -y --no-install-recommends install \
   apache2 \
   bind9-host \
   ca-certificates \
@@ -68,7 +64,7 @@ RUN apt-get update \
   telnet \
   unzip \
   wget \
-&& apt-get -y autoremove && apt-get -y autoclean && apt-get clean && rm -rf /var/lib/apt/lists /tmp/* /var/tmp/*
+  && apt-get -y autoremove && apt-get -y autoclean && apt-get clean && rm -rf /var/lib/apt/lists /tmp/* /var/tmp/*
 
 # NewRelic is disabled by default.
 ENV NEW_RELIC_ENABLED=false
@@ -78,13 +74,13 @@ RUN rm -f /etc/php/${PHP}/mods-available/newrelic.ini /etc/php/${PHP}/apache2/co
 
 # Allow insecure SSL negotiation for CURL problems with RSS feeds.
 RUN sed -i '/^providers = provider_sect/a \
-ssl_conf = ssl_sect\n\
-\n\
-[ssl_sect]\n\
-system_default = system_default_sect\n\
-\n\
-[system_default_sect]\n\
-Options = UnsafeLegacyServerConnect' /etc/ssl/openssl.cnf
+  ssl_conf = ssl_sect\n\
+  \n\
+  [ssl_sect]\n\
+  system_default = system_default_sect\n\
+  \n\
+  [system_default_sect]\n\
+  Options = UnsafeLegacyServerConnect' /etc/ssl/openssl.cnf
 
 # Set the PHP interpreter to the correct one.
 RUN update-alternatives --set php /usr/bin/php${PHP}
@@ -94,7 +90,7 @@ RUN wget -q -O - https://getcomposer.org/installer | php -- --install-dir=/usr/l
 
 # Install PHP Local Security Checker
 RUN wget -q -O /usr/local/bin/local-php-security-checker https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.6/local-php-security-checker_2.0.6_linux_amd64 \
-&& chmod +rx /usr/local/bin/local-php-security-checker
+  && chmod +rx /usr/local/bin/local-php-security-checker
 
 # Apache config.
 COPY ./files/apache2.conf /etc/apache2/apache2.conf
@@ -106,11 +102,11 @@ COPY ./files/newrelic.ini /etc/php/${PHP}/apache2/conf.d/newrelic.ini
 
 # Configure apache modules, php modules, logging.
 RUN a2enmod rewrite \
-&& a2enmod mpm_prefork \
-&& a2dismod vhost_alias \
-&& a2disconf other-vhosts-access-log \
-&& a2dissite 000-default \
-&& phpenmod -v ALL -s ALL php_custom
+  && a2enmod mpm_prefork \
+  && a2dismod vhost_alias \
+  && a2disconf other-vhosts-access-log \
+  && a2dissite 000-default \
+  && phpenmod -v ALL -s ALL php_custom
 
 # Add /code /shared directories and ensure ownership by User 33 (www-data) and Group 0 (root).
 RUN mkdir -p /code/web /shared
@@ -128,20 +124,20 @@ WORKDIR /code
 
 # Change all ownership to User 33 (www-data) and Group 0 (root).
 RUN chown -R 33:0   /var/www \
-&&  chown -R 33:0   /run/lock \
-&&  chown -R 33:0   /var/run/apache2 \
-&&  chown -R 33:0   /var/log/apache2 \
-&&  chown -R 33:0   /code \
-&&  chown -R 33:0   /shared
+  &&  chown -R 33:0   /run/lock \
+  &&  chown -R 33:0   /var/run/apache2 \
+  &&  chown -R 33:0   /var/log/apache2 \
+  &&  chown -R 33:0   /code \
+  &&  chown -R 33:0   /shared
 
 RUN chmod -R g+rwX  /var/www \
-&&  chmod -R g+rwX  /run/lock \
-&&  chmod -R g+rwX  /var/run/apache2 \
-&&  chmod -R g+rwX  /var/log/apache2 \
-&&  chmod -R g+rwX  /code \
-&&  chmod -R g+rwX  /shared \
-&&  chmod g+s /code \
-&&  chmod g+s /code/web
+  &&  chmod -R g+rwX  /run/lock \
+  &&  chmod -R g+rwX  /var/run/apache2 \
+  &&  chmod -R g+rwX  /var/log/apache2 \
+  &&  chmod -R g+rwX  /code \
+  &&  chmod -R g+rwX  /shared \
+  &&  chmod g+s /code \
+  &&  chmod g+s /code/web
 
 # Change the homedir of www-data to be /code.
 RUN usermod -d /code www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=Australia/Adelaide
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# Workaround for New Relic package being signed with an unsupported signing key.
+# See https://support.newrelic.com/s/hubtopic/aAXPh000000BZYjOAO/gpg-errors-when-installing-linux-net-and-php-agents-on-ubuntu-noble-2404
+RUN apt-config dump | grep -we 'APT::Key::Assert-Pubkey-Algo "' | sed 's/";/,dsa1024";/' | tee /etc/apt/apt.conf.d/99PubKeyAlgoWorkaround
+
 # Upgrade all currently installed packages and install web server packages.
 RUN apt-get update \
 && apt-get -y --no-install-recommends install ca-certificates apt apt-utils \


### PR DESCRIPTION
By default, Ubuntu 24.04 doesn't allow the signing key used by the newrelic package.